### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A Xircuits component library that wraps Thespian, the framework of an Actor model for use by applications implementing Actors."
 authors = [{ name = "XpressAI", email = "eduardo@xpress.ai" }]
 license = "Apache-2.0"
-readme = "readme.md"
+readme = "README.md"
 repository = "https://github.com/XpressAI/xai-actors"
 keywords = ["xircuits", "thespian", "actor"]
 


### PR DESCRIPTION
# Description

This PR fixes metadata issues in the `pyproject.toml` of **xai-actors**:
- Corrected `readme` casing to `README.md`.